### PR TITLE
Add infiniband variant to gfarm package

### DIFF
--- a/packages/gfarm/package.py
+++ b/packages/gfarm/package.py
@@ -7,8 +7,10 @@ from spack import *
 
 
 class Gfarm(AutotoolsPackage):
-    """Gfarm file system is a distributed file system for large-scale cluster computing and wide-area data sharing.
-    It provides fine-grained replica location control. """
+    """Gfarm file system is a distributed file system for large-scale
+    cluster computing and wide-area data sharing. It provides
+    fine-grained replica location control.
+    """
 
     homepage = 'http://oss-tsukuba.org/software/gfarm'
     url = 'https://github.com/oss-tsukuba/gfarm/archive/2.7.17.tar.gz'
@@ -20,6 +22,17 @@ class Gfarm(AutotoolsPackage):
     depends_on('openssl')
     depends_on('postgresql')
 
+    variant('infiniband', default='none', description='Specifies to use RDMA through InfiniBand. You can specify the custome prefix for InifiniBand (i.e. \
+`infiniband_path=/usr/local`).')
+
     def configure_args(self):
         args = []
+
+        infiniband = self.spec.variants['infiniband'].value
+        if infiniband != 'none':
+            if '+infiniband' in self.spec:
+                args.append('--with-infiniband')
+            else:
+                args.append('--with-infiniband={0}'.format(infiniband))
+
         return args


### PR DESCRIPTION
This PR enables the gfarm package to use the `infiniband` variant.